### PR TITLE
code bit to overwrite the default CLIMAParameters

### DIFF
--- a/src/KiD_driver.jl
+++ b/src/KiD_driver.jl
@@ -3,8 +3,16 @@ include("KiD.jl")
 const FT = Float64
 
 # Instantiate CliMA Parameters
-struct AEPS <: CP.AbstractEarthParameterSet end
-params = AEPS()
+struct EarthParameterSet{NT} <: CP.AbstractEarthParameterSet
+    nt::NT
+end
+CP.Planet.MSLP(ps::EarthParameterSet) = ps.nt.MSLP
+nt = (;
+    MSLP = 100000.0,
+)
+params = EarthParameterSet(nt)
+
+print(CP.Planet.MSLP(params))
 
 # Set up the computational domain and time step
 z_min = FT(0)


### PR DESCRIPTION
@edejong-caltech - here is a draft on how to overwrite the default CLIMAParameters. If you need to overwrite more of them just extend the named tupele `nt` and assign them to overwrite the correct CliMAParameters.

But my hunch is that setting the reference pressure should solve our dry case issues