### PR TITLE
add up_deps and formatter scripts

### DIFF
--- a/.dev/.gitignore
+++ b/.dev/.gitignore
@@ -1,0 +1,1 @@
+Manifest.toml

--- a/.dev/Project.toml
+++ b/.dev/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
+
+[compat]
+JuliaFormatter = "0.22"

--- a/.dev/clima_formatter_options.jl
+++ b/.dev/clima_formatter_options.jl
@@ -1,0 +1,8 @@
+clima_formatter_options = (
+    indent = 4,
+    margin = 120,
+    always_for_in = true,
+    whitespace_typedefs = true,
+    whitespace_ops_in_indices = true,
+    remove_extra_newlines = false,
+)

--- a/.dev/climaformat.jl
+++ b/.dev/climaformat.jl
@@ -1,0 +1,85 @@
+#!/usr/bin/env julia
+#
+# This is an adapted version of format.jl from JuliaFormatter with the
+# following license:
+#
+#    MIT License
+#    Copyright (c) 2019 Dominique Luna
+#
+#    Permission is hereby granted, free of charge, to any person obtaining a
+#    copy of this software and associated documentation files (the
+#    "Software"), to deal in the Software without restriction, including
+#    without limitation the rights to use, copy, modify, merge, publish,
+#    distribute, sublicense, and/or sell copies of the Software, and to permit
+#    persons to whom the Software is furnished to do so, subject to the
+#    following conditions:
+#
+#    The above copyright notice and this permission notice shall be included
+#    in all copies or substantial portions of the Software.
+#
+#    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+#    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+#    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+#    NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+#    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+#    OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+#    USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+using Pkg
+Pkg.activate(@__DIR__)
+Pkg.instantiate()
+
+using JuliaFormatter
+
+include("clima_formatter_options.jl")
+
+help = """
+Usage: climaformat.jl [flags] [FILE/PATH]...
+
+Formats the given julia files using the CLIMA formatting options.  If paths
+are given it will format the julia files in the paths. Otherwise, it will
+format all changed julia files.
+
+    -v, --verbose
+        Print the name of the files being formatted with relevant details.
+
+    -h, --help
+        Print this message.
+"""
+
+function parse_opts!(args::Vector{String})
+    i = 1
+    opts = Dict{Symbol, Union{Int, Bool}}()
+    while i ≤ length(args)
+        arg = args[i]
+        if arg[1] != '-'
+            i += 1
+            continue
+        end
+        if arg == "-v" || arg == "--verbose"
+            opt = :verbose
+        elseif arg == "-h" || arg == "--help"
+            opt = :help
+        else
+            error("invalid option $arg")
+        end
+        if opt in (:verbose, :help)
+            opts[opt] = true
+            deleteat!(args, i)
+        end
+    end
+    return opts
+end
+
+opts = parse_opts!(ARGS)
+if haskey(opts, :help)
+    write(stdout, help)
+    exit(0)
+end
+if isempty(ARGS)
+    filenames = readlines(`git ls-files "*.jl"`)
+else
+    filenames = ARGS
+end
+
+format(filenames; clima_formatter_options..., opts...)

--- a/.dev/hooks/pre-commit
+++ b/.dev/hooks/pre-commit
@@ -1,0 +1,41 @@
+#!/usr/bin/env julia
+#
+# Called by git-commit with no arguments.  This checks to make sure that all
+# .jl files are indented correctly before a commit is made.
+#
+# To enable this hook, make this file executable and copy it in
+# $GIT_DIR/hooks.
+
+toplevel_directory = chomp(read(`git rev-parse --show-toplevel`, String))
+
+using Pkg
+Pkg.activate(joinpath(toplevel_directory, ".dev"))
+Pkg.instantiate()
+
+using JuliaFormatter
+
+include(joinpath(toplevel_directory, ".dev", "clima_formatter_options.jl"))
+
+needs_format = false
+
+for diffoutput in split.(readlines(`git diff --name-status --cached`))
+    status = diffoutput[1]
+    filename = diffoutput[end]
+    (!startswith(status, "D") && endswith(filename, ".jl")) || continue
+
+    a = read(`git show :$filename`, String)
+    b = format_text(a; clima_formatter_options...)
+
+    if a != b
+        fullfilename = joinpath(toplevel_directory, filename)
+
+        @error """File $filename needs to be indented with:
+            julia $(joinpath(toplevel_directory, ".dev", "climaformat.jl")) $fullfilename
+        and added to the git index via
+            git add $fullfilename
+        """
+        global needs_format = true
+    end
+end
+
+exit(needs_format ? 1 : 0)

--- a/.dev/up_deps.jl
+++ b/.dev/up_deps.jl
@@ -1,0 +1,22 @@
+#=
+A simple script for updating the manifest
+files in all of our environments.
+=#
+
+root = dirname(@__DIR__)
+dirs = (root, joinpath(root, "test"))
+
+cd(root) do
+    for dir in dirs
+        @info "Pkg.up for environment $dir"
+        cmd = `$(Base.julia_cmd()) --project=$dir -e 'import Pkg; Pkg.update()'`
+        run(cmd)
+    end
+end
+
+# https://github.com/JuliaLang/Pkg.jl/issues/3014
+for dir in dirs
+    cd(dir) do
+        rm("LocalPreferences.toml"; force = true)
+    end
+end

--- a/.github/workflows/JuliaFormatter.yml
+++ b/.github/workflows/JuliaFormatter.yml
@@ -1,0 +1,44 @@
+name: JuliaFormatter
+
+on:
+  push:
+    branches:
+      - main
+      - trying
+      - staging
+    tags: '*'
+  pull_request:
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.4.0
+      with:
+        access_token: ${{ github.token }}
+
+    - uses: actions/checkout@v2.2.0
+
+    - uses: dorny/paths-filter@v2.9.1
+      id: filter
+      with:
+        filters: |
+          julia_file_change:
+            - added|modified: '**.jl'
+
+    - uses: julia-actions/setup-julia@latest
+      if: steps.filter.outputs.julia_file_change == 'true'
+      with:
+        version: 1.7.0
+
+    - name: Apply JuliaFormatter
+      if: steps.filter.outputs.julia_file_change == 'true'
+      run: |
+        julia --project=.dev .dev/climaformat.jl .
+
+    - name: Check formatting diff
+      if: steps.filter.outputs.julia_file_change == 'true'
+      run: |
+        git diff --color=always --exit-code

--- a/src/KiD_driver.jl
+++ b/src/KiD_driver.jl
@@ -11,9 +11,7 @@ struct EarthParameterSet{NT} <: CP.AbstractEarthParameterSet
     nt::NT
 end
 CP.Planet.MSLP(ps::EarthParameterSet) = ps.nt.MSLP
-nt = (;
-    MSLP = 100000.0,
-)
+nt = (; MSLP = 100000.0)
 params = EarthParameterSet(nt)
 
 # Set up the computational domain and time step
@@ -103,27 +101,9 @@ q_liq_end = parent(aux.q_liq)
 q_ice_end = parent(aux.q_ice)
 ρq_tot_end = parent(solver.u[end].ρq_tot)
 
-Plots.png(
-    Plots.plot(θ_liq_ice_end, z_centers),
-    joinpath(path, "KM_θ_end.png"),
-)
-Plots.png(
-    Plots.plot(ρq_tot_end ./ ρ, z_centers),
-    joinpath(path, "KM_qt_end.png"),
-)
-Plots.png(
-    Plots.plot(q_liq_end, z_centers),
-    joinpath(path, "KM_ql_end.png"),
-)
-Plots.png(
-    Plots.plot(q_ice_end, z_centers),
-    joinpath(path, "KM_qi_end.png"),
-)
-Plots.png(
-    Plots.plot(T_end, z_centers),
-    joinpath(path, "KM_T_end.png"),
-)
-Plots.png(
-    Plots.plot(ρ, z_centers),
-    joinpath(path, "KM_ρ.png"),
-)
+Plots.png(Plots.plot(θ_liq_ice_end, z_centers), joinpath(path, "KM_θ_end.png"))
+Plots.png(Plots.plot(ρq_tot_end ./ ρ, z_centers), joinpath(path, "KM_qt_end.png"))
+Plots.png(Plots.plot(q_liq_end, z_centers), joinpath(path, "KM_ql_end.png"))
+Plots.png(Plots.plot(q_ice_end, z_centers), joinpath(path, "KM_qi_end.png"))
+Plots.png(Plots.plot(T_end, z_centers), joinpath(path, "KM_T_end.png"))
+Plots.png(Plots.plot(ρ, z_centers), joinpath(path, "KM_ρ.png"))

--- a/src/KiD_model.jl
+++ b/src/KiD_model.jl
@@ -25,10 +25,7 @@ end
    right hand side of the solved ODE. The rhs is assembled via dispatch
    based on the moisture and precipitation types.
 """
-function make_rhs_function(
-    moisture::AbstractMoistureStyle,
-    precipitation::AbstractPrecipitationStyle,
-)
+function make_rhs_function(moisture::AbstractMoistureStyle, precipitation::AbstractPrecipitationStyle)
     function rhs!(dY, Y, aux, t)
         zero_tendencies!(moisture, precipitation, dY, Y, aux, t)
         precompute_aux!(moisture, precipitation, dY, Y, aux, t)
@@ -44,40 +41,24 @@ end
     ODE solver state variables. The state is created via dispatching
     on different moisture and precipitation types
 """
-function initialise_state(
-    ::EquilibriumMoisture,
-    ::Union{NoPrecipitation, Precipitation0M},
-    initial_profiles,
-)
+function initialise_state(::EquilibriumMoisture, ::Union{NoPrecipitation, Precipitation0M}, initial_profiles)
     return CC.Fields.FieldVector(; ρq_tot = initial_profiles.ρq_tot)
 end
-function initialise_state(
-    ::NonEquilibriumMoisture,
-    ::Union{NoPrecipitation, Precipitation0M},
-    initial_profiles,
-)
+function initialise_state(::NonEquilibriumMoisture, ::Union{NoPrecipitation, Precipitation0M}, initial_profiles)
     return CC.Fields.FieldVector(;
         ρq_tot = initial_profiles.ρq_tot,
         ρq_liq = initial_profiles.ρq_liq,
         ρq_ice = initial_profiles.ρq_ice,
     )
 end
-function initialise_state(
-    ::EquilibriumMoisture,
-    ::Precipitation1M,
-    initial_profiles,
-)
+function initialise_state(::EquilibriumMoisture, ::Precipitation1M, initial_profiles)
     return CC.Fields.FieldVector(;
         ρq_tot = initial_profiles.ρq_tot,
         ρq_rai = initial_profiles.ρq_rai,
         ρq_sno = initial_profiles.ρq_sno,
     )
 end
-function initialise_state(
-    ::NonEquilibriumMoisture,
-    ::Precipitation1M,
-    initial_profiles,
-)
+function initialise_state(::NonEquilibriumMoisture, ::Precipitation1M, initial_profiles)
     return CC.Fields.FieldVector(;
         ρq_tot = initial_profiles.ρq_tot,
         ρq_liq = initial_profiles.ρq_liq,
@@ -92,16 +73,7 @@ end
    The auxiliary state is created as a ClimaCore FieldVector
    and passed to ODE solver via the `p` parameter of the ODEProblem.
 """
-function initialise_aux(
-    initial_profiles,
-    params,
-    w_params,
-    q_surf,
-    ρw0,
-    TS,
-    Stats,
-    face_space,
-)
+function initialise_aux(initial_profiles, params, w_params, q_surf, ρw0, TS, Stats, face_space)
     ρw = CC.Geometry.WVector.(zeros(FT, face_space))
 
     return CC.Fields.FieldVector(;

--- a/src/NetCDFIO.jl
+++ b/src/NetCDFIO.jl
@@ -37,18 +37,18 @@ function NetCDFIO_Stats(nc_filename, output_interval, z_faces, z_centers)
         NC.defVar(profile_grp, "t", Float64, ("t",))
 
         # TODO - define output variables based on the model that is being run?
-        NC.defVar(profile_grp, "density", FT, ("zc","t"))
-        NC.defVar(profile_grp, "temperature", FT, ("zc","t"))
-        NC.defVar(profile_grp, "pressure", FT, ("zc","t"))
+        NC.defVar(profile_grp, "density", FT, ("zc", "t"))
+        NC.defVar(profile_grp, "temperature", FT, ("zc", "t"))
+        NC.defVar(profile_grp, "pressure", FT, ("zc", "t"))
 
-        NC.defVar(profile_grp, "theta_liq_ice", FT, ("zc","t"))
-        NC.defVar(profile_grp, "theta_dry", FT, ("zc","t"))
+        NC.defVar(profile_grp, "theta_liq_ice", FT, ("zc", "t"))
+        NC.defVar(profile_grp, "theta_dry", FT, ("zc", "t"))
 
-        NC.defVar(profile_grp, "q_tot", FT, ("zc","t"))
-        NC.defVar(profile_grp, "q_liq", FT, ("zc","t"))
-        NC.defVar(profile_grp, "q_ice", FT, ("zc","t"))
-        NC.defVar(profile_grp, "q_rai", FT, ("zc","t"))
-        NC.defVar(profile_grp, "q_sno", FT, ("zc","t"))
+        NC.defVar(profile_grp, "q_tot", FT, ("zc", "t"))
+        NC.defVar(profile_grp, "q_liq", FT, ("zc", "t"))
+        NC.defVar(profile_grp, "q_ice", FT, ("zc", "t"))
+        NC.defVar(profile_grp, "q_rai", FT, ("zc", "t"))
+        NC.defVar(profile_grp, "q_sno", FT, ("zc", "t"))
 
         reference_grp = NC.defGroup(root_grp, "reference")
         NC.defDim(reference_grp, "zf", length(z_faces))

--- a/src/initial_condition.jl
+++ b/src/initial_condition.jl
@@ -18,18 +18,18 @@ function init_condition(::Type{FT}, params, z) where {FT}
     θ_2::FT = 312.66
 
     # profile of water vapour specific humidity (TODO - or is it mixing ratio?)
-    qv::FT = z < z_1 ? qv_0 + (qv_1 - qv_0)/(z_1 - z_0) * (z - z_0) : qv_1 + (qv_2 - qv_1)/(z_2 - z_1) * (z - z_1)
+    qv::FT = z < z_1 ? qv_0 + (qv_1 - qv_0) / (z_1 - z_0) * (z - z_0) : qv_1 + (qv_2 - qv_1) / (z_2 - z_1) * (z - z_1)
 
     # profile of potential temperature
-    θ::FT = z < z_1 ? θ_0 : θ_1 + (θ_2 - θ_1)/(z_2 - z_1) * (z - z_1)
+    θ::FT = z < z_1 ? θ_0 : θ_1 + (θ_2 - θ_1) / (z_2 - z_1) * (z - z_1)
 
     # density at the surface
     p_0::FT = 100200.0
     q_0 = TD.PhasePartition(qv_0, 0.0, 0.0)
-    T_0::FT = θ_0 * TD.exner_given_pressure(params, p_0,  q_0)
+    T_0::FT = θ_0 * TD.exner_given_pressure(params, p_0, q_0)
     ρ_0::FT = TD.air_density(params, T_0, p_0, q_0)
 
-    return(qv = qv, θ = θ, ρ_0 = ρ_0, z_0 = z_0, z_2 = z_2)
+    return (qv = qv, θ = θ, ρ_0 = ρ_0, z_0 = z_0, z_2 = z_2)
 end
 
 """
@@ -48,18 +48,18 @@ function init_condition_dry(::Type{FT}, params, z) where {FT}
     θ_2::FT = 312.66
 
     # profile of water vapour specific humidity (TODO - or is it mixing ratio?)
-    qv::FT = z < z_1 ? qv_0 + (qv_1 - qv_0)/(z_1 - z_0) * (z - z_0) : qv_1 + (qv_2 - qv_1)/(z_2 - z_1) * (z - z_1)
+    qv::FT = z < z_1 ? qv_0 + (qv_1 - qv_0) / (z_1 - z_0) * (z - z_0) : qv_1 + (qv_2 - qv_1) / (z_2 - z_1) * (z - z_1)
 
     # profile of potential temperature
-    θ::FT = z < z_1 ? θ_0 : θ_1 + (θ_2 - θ_1)/(z_2 - z_1) * (z - z_1)
+    θ::FT = z < z_1 ? θ_0 : θ_1 + (θ_2 - θ_1) / (z_2 - z_1) * (z - z_1)
 
     # density at the surface
     p_0::FT = 100200.0
     q_0 = TD.PhasePartition(qv_0, 0.0, 0.0)
-    T_0::FT = θ_0 * TD.exner_given_pressure(params, p_0,  q_0)
+    T_0::FT = θ_0 * TD.exner_given_pressure(params, p_0, q_0)
     ρ_0::FT = TD.air_density(params, T_0, p_0, q_0)
 
-    return(qv = qv, θ = θ, ρ_0 = ρ_0, z_0 = z_0, z_2 = z_2)
+    return (qv = qv, θ = θ, ρ_0 = ρ_0, z_0 = z_0, z_2 = z_2)
 end
 
 """
@@ -100,7 +100,7 @@ function ρ_ivp(::Type{FT}, params) where {FT}
 
     z_span = (z_0, z_max)
     prob = ODE.ODEProblem(dρ_dz!, ρ_0, z_span, params)
-    sol = ODE.solve(prob, ODE.Tsit5(), reltol=1e-8, abstol=1e-8)
+    sol = ODE.solve(prob, ODE.Tsit5(), reltol = 1e-8, abstol = 1e-8)
 
     return sol
 end
@@ -133,5 +133,5 @@ function init_1d_column(::Type{FT}, params, ρ_profile, z) where {FT}
     ρq_rai::FT = q_rai * ρ
     ρq_sno::FT = q_sno * ρ
 
-    return(; ρ, T, p, θ_liq_ice, θ_dry, ρq_tot, ρq_liq, ρq_ice, ρq_rai, ρq_sno, q_tot, q_liq, q_ice, q_rai, q_sno)
+    return (; ρ, T, p, θ_liq_ice, θ_dry, ρq_tot, ρq_liq, ρq_ice, ρq_rai, ρq_sno, q_tot, q_liq, q_ice, q_rai, q_sno)
 end

--- a/src/tendency.jl
+++ b/src/tendency.jl
@@ -22,10 +22,10 @@ function precompute_aux!(::EquilibriumMoisture, ::NoPrecipitation, dY, Y, aux, t
     @. aux.q_tot = TD.total_specific_humidity(aux.params, ts)
     @. aux.q_liq = TD.liquid_specific_humidity(aux.params, ts)
     @. aux.q_ice = TD.ice_specific_humidity(aux.params, ts)
-    @. aux.T     = TD.air_temperature(aux.params, ts)
-    @. aux.ρw    = CC.Geometry.WVector.(aux.w_params.w1 * sin(pi * t / aux.w_params.t1))
+    @. aux.T = TD.air_temperature(aux.params, ts)
+    @. aux.ρw = CC.Geometry.WVector.(aux.w_params.w1 * sin(pi * t / aux.w_params.t1))
 
-    aux.ρw0      = aux.w_params.w1 * sin(pi * t / aux.w_params.t1)
+    aux.ρw0 = aux.w_params.w1 * sin(pi * t / aux.w_params.t1)
 end
 
 """
@@ -34,16 +34,13 @@ end
 function advection_tendency!(::EquilibriumMoisture, ::NoPrecipitation, dY, Y, aux, t)
     FT = eltype(Y.ρq_tot)
 
-    fcc = CC.Operators.FluxCorrectionC2C(
-        bottom = CC.Operators.Extrapolate(),
-        top = CC.Operators.Extrapolate(),
-    )
+    fcc = CC.Operators.FluxCorrectionC2C(bottom = CC.Operators.Extrapolate(), top = CC.Operators.Extrapolate())
     If = CC.Operators.InterpolateC2F()
     ∂ = CC.Operators.DivergenceF2C(
         bottom = CC.Operators.SetValue(CC.Geometry.WVector(aux.ρw0 * aux.q_surf)), # TODO: change to correct ρvw_0 b.c.
         top = CC.Operators.Extrapolate(),
     )
-    @. dY.ρq_tot  += -(∂(aux.ρw / If(aux.ρ) * If(Y.ρq_tot))) + fcc(aux.ρw / If(aux.ρ), Y.ρq_tot)
+    @. dY.ρq_tot += -(∂(aux.ρw / If(aux.ρ) * If(Y.ρq_tot))) + fcc(aux.ρw / If(aux.ρ), Y.ρq_tot)
 
     #CC.Spaces.weighted_dss!(dY.ρq_tot)
     return dY


### PR DESCRIPTION
This PR adds a julia formatter script and hooks it with GitHub workflows. So that we check if we follow the formatting conventions before merging. 

It also adds a convenience up_deps.jl script for managing the dependencies. This will come in handy once we have separate toml files in folders such ad docs and tests.