### PR TITLE
add initial moist profiles to tests (currently broken)

### DIFF
--- a/test/data_utils.jl
+++ b/test/data_utils.jl
@@ -3,27 +3,27 @@ using Plots
 """
     Create plots comparing the Julia & PySDM vertical profiles
 """
-function plot_comparison(KM_data; sdm_case = "dry", dir = "dry")
+function plot_comparison(KM; sdm_case = "dry", dir = "dry")
     sdm_data = load_sdm_data(sdm_case)
     path = joinpath(@__DIR__, "output", dir)
     mkpath(path)
 
-    p1 = Plots.plot(KM_data.q_vap, z_centers, label = "KM", xlabel = "q_vap [g/kg]", ylabel = "z [m]")
+    p1 = Plots.plot(KM.q_vap, KM.z_centers, label = "KM", xlabel = "q_vap [g/kg]", ylabel = "z [m]")
     Plots.plot!(p1, sdm_data.qv_sdm, sdm_data.z_sdm, label = "SDM")
 
-    p2 = Plots.plot(KM_data.ρ, z_centers, label = "KM ρ_tot", xlabel = "ρ [kg/m3]", ylabel = "z [m]")
+    p2 = Plots.plot(KM.ρ, KM.z_centers, label = "KM ρ_tot", xlabel = "ρ [kg/m3]", ylabel = "z [m]")
     Plots.plot!(p2, sdm_data.rho_sdm, sdm_data.z_sdm, label = "SDM ρ")
 
-    p3 = Plots.plot(KM_data.θ_dry, z_centers, label = "KM", xlabel = "θ_dry [K]", ylabel = "z [m]")
+    p3 = Plots.plot(KM.θ_dry, KM.z_centers, label = "KM", xlabel = "θ_dry [K]", ylabel = "z [m]")
     Plots.plot!(p3, sdm_data.thetad_sdm, sdm_data.z_sdm, label = "SDM")
 
-    p4 = Plots.plot(KM_data.T, z_centers, label = "KM", xlabel = "T [K]", ylabel = "z [m]")
+    p4 = Plots.plot(KM.T, KM.z_centers, label = "KM", xlabel = "T [K]", ylabel = "z [m]")
     Plots.plot!(p4, sdm_data.T_sdm, sdm_data.z_sdm, label = "SDM")
 
-    p5 = Plots.plot(KM_data.p, z_centers, label = "KM", xlabel = "p [Pa]", ylabel = "z [m]")
+    p5 = Plots.plot(KM.p, KM.z_centers, label = "KM", xlabel = "p [Pa]", ylabel = "z [m]")
     Plots.plot!(p5, sdm_data.P_sdm, sdm_data.z_sdm, label = "SDM")
 
-    p6 = Plots.plot(KM_data.q_liq, z_centers, label = "KM", xlabel = "q_liq [g/kg]", ylabel = "z [m]")
+    p6 = Plots.plot(KM.q_liq, KM.z_centers, label = "KM", xlabel = "q_liq [g/kg]", ylabel = "z [m]")
     Plots.plot!(p6, sdm_data.ql_sdm, sdm_data.z_sdm, label = "SDM")
 
     p = Plots.plot(p1, p2, p3, p4, p5, p6, size = (1000, 600))

--- a/test/initial_profile_test.jl
+++ b/test/initial_profile_test.jl
@@ -3,75 +3,93 @@ Test that initial profiles match between CliMA and PySDM
 """
 
 include("data_utils.jl")
-
 const FT = Float64
 
-# TODO - make them test parameters
-dry = true
-if dry
-    sdm_case = "dry_coarse"
-else
-    sdm_case = "wet"
+function compare_profiles(; is_dry_flag::Bool)
+    # Computational domain ...
+    z_min = FT(0)
+    z_max = FT(2220)
+    n_elem = 222 # TODO: run PySDM with 20m resolution
+    # ... and the created coordinates
+    space, face_space = KiD.make_function_space(FT, z_min, z_max, n_elem)
+    coord = CC.Fields.coordinate_field(space)
+    face_coord = CC.Fields.coordinate_field(face_space)
+
+    # Solve the initial value problem for density profile
+    ρ_profile = KiD.ρ_ivp(FT, params, dry = is_dry_flag)
+    # Create the initial condition profiles
+    init = map(coord -> KiD.init_1d_column(FT, params, ρ_profile, coord.z, dry = is_dry_flag), coord)
+
+    # Store the CliMA KiD initial profiles
+    z_centers = parent(CC.Fields.coordinate_field(space))
+    T = parent(init.T)
+    p = parent(init.p)
+    ρ = parent(init.ρ)
+    θ_dry = parent(init.θ_dry)
+    q_vap = parent(init.q_tot) - parent(init.q_liq) - parent(init.q_ice)
+    q_liq = parent(init.q_liq)
+    KM_data = (; z_centers, q_vap, ρ, θ_dry, T, p, q_liq)
+
+    # Read in the PySDM KiD initial profiles
+    sdm_case = is_dry_flag ? "dry_coarse" : "wet"
+    sdm_data = load_sdm_data(sdm_case)
+
+    # Interpolate both (we are not doing computations on the same grid)
+    KM_T = IP.LinearInterpolation(KM_data.z_centers[:], KM_data.T[:], extrapolation_bc = IP.Line())
+    KM_p = IP.LinearInterpolation(KM_data.z_centers[:], KM_data.p[:], extrapolation_bc = IP.Line())
+    KM_ρ = IP.LinearInterpolation(KM_data.z_centers[:], KM_data.ρ[:], extrapolation_bc = IP.Line())
+    KM_q_liq = IP.LinearInterpolation(KM_data.z_centers[:], KM_data.q_liq[:], extrapolation_bc = IP.Line())
+    KM_q_vap = IP.LinearInterpolation(KM_data.z_centers[:], KM_data.q_vap[:], extrapolation_bc = IP.Line())
+    KM_θ_dry = IP.LinearInterpolation(KM_data.z_centers[:], KM_data.θ_dry[:], extrapolation_bc = IP.Line())
+
+    SD_T = IP.LinearInterpolation(sdm_data.z_sdm, sdm_data.T_sdm, extrapolation_bc = IP.Line())
+    SD_p = IP.LinearInterpolation(sdm_data.z_sdm, sdm_data.P_sdm, extrapolation_bc = IP.Line())
+    SD_ρ = IP.LinearInterpolation(sdm_data.z_sdm, sdm_data.rho_sdm, extrapolation_bc = IP.Line())
+    SD_q_liq = IP.LinearInterpolation(sdm_data.z_sdm, sdm_data.ql_sdm, extrapolation_bc = IP.Line())
+    SD_q_vap = IP.LinearInterpolation(sdm_data.z_sdm, sdm_data.qv_sdm, extrapolation_bc = IP.Line())
+    SD_θ_dry = IP.LinearInterpolation(sdm_data.z_sdm, sdm_data.thetad_sdm, extrapolation_bc = IP.Line())
+
+    # Test that the initial profiles match between CliMA and PySDM
+    test_title = "Case: " * sdm_case * ". Initial profiles of water (vapour and liquid):"
+    @testset "$test_title" begin
+        z_test = z_min:100:z_max
+        @test all(isapprox(KM_q_vap(z_test), SD_q_vap(z_test), rtol = 1e-6))
+        @test all(isapprox(KM_q_liq(z_test), SD_q_liq(z_test), rtol = 1e-6))
+    end
+
+    test_title = "Case: " * sdm_case * ". Initial profiles of (T, p, ρ):"
+    if is_dry_flag
+        @testset "$test_title" begin
+            z_test = z_min:100:z_max
+            @test all(isapprox(KM_T(z_test), SD_T(z_test), rtol = 1e-3))
+            @test all(isapprox(KM_p(z_test), SD_p(z_test), rtol = 1e-3))
+            @test all(isapprox(KM_ρ(z_test), SD_ρ(z_test), rtol = 1e-3))
+        end
+    else
+        @testset "$test_title" begin
+            z_test = z_min:100:z_max
+            @test_broken all(isapprox(KM_T(z_test), SD_T(z_test), rtol = 1e-3))
+            @test_broken all(isapprox(KM_p(z_test), SD_p(z_test), rtol = 1e-3))
+            @test_broken all(isapprox(KM_ρ(z_test), SD_ρ(z_test), rtol = 1e-3))
+        end
+    end
+
+    test_title = "Case: " * sdm_case * ". Initial profiles of θ_dry:"
+    if is_dry_flag
+        @testset "$test_title" begin
+            z_test = z_min:100:z_max
+            @test all(isapprox(KM_θ_dry(z_test), SD_θ_dry(z_test), rtol = 1e-4))
+        end
+    else
+        @testset "$test_title" begin
+            z_test = z_min:100:z_max
+            @test_broken all(isapprox(KM_θ_dry(z_test), SD_θ_dry(z_test), rtol = 1e-4))
+        end
+    end
+
+    # Plot the profiles - TODO connect with buildkite artifacts
+    plot_comparison(KM_data, sdm_case = sdm_case, dir = sdm_case)
 end
 
-# Computational domain ...
-z_min = FT(0)
-z_max = FT(2220)
-n_elem = 222 # TODO: run PySDM with 20m resolution
-# ... and the created coordinates
-space, face_space = KiD.make_function_space(FT, z_min, z_max, n_elem)
-coord = CC.Fields.coordinate_field(space)
-face_coord = CC.Fields.coordinate_field(face_space)
-
-# Solve the initial value problem for density profile
-ρ_profile = KiD.ρ_ivp(FT, params, dry = dry)
-# Create the initial condition profiles
-init = map(coord -> KiD.init_1d_column(FT, params, ρ_profile, coord.z, dry = dry), coord)
-
-# Store the CliMA KiD initial profiles
-z_centers = parent(CC.Fields.coordinate_field(space))
-T = parent(init.T)
-p = parent(init.p)
-ρ = parent(init.ρ)
-θ_dry = parent(init.θ_dry)
-q_vap = parent(init.q_tot) - parent(init.q_liq) - parent(init.q_ice)
-q_liq = parent(init.q_liq)
-KM_data = (; z_centers, q_vap, ρ, θ_dry, T, p, q_liq)
-
-# Read in the PySDM KiD initial profiles
-sdm_data = load_sdm_data(sdm_case)
-
-# Interpolate both (we are not doing computations on the same grid)
-KM_T = IP.LinearInterpolation(KM_data.z_centers[:], KM_data.T[:], extrapolation_bc = IP.Line())
-KM_p = IP.LinearInterpolation(KM_data.z_centers[:], KM_data.p[:], extrapolation_bc = IP.Line())
-KM_ρ = IP.LinearInterpolation(KM_data.z_centers[:], KM_data.ρ[:], extrapolation_bc = IP.Line())
-KM_q_liq = IP.LinearInterpolation(KM_data.z_centers[:], KM_data.q_liq[:], extrapolation_bc = IP.Line())
-KM_q_vap = IP.LinearInterpolation(KM_data.z_centers[:], KM_data.q_vap[:], extrapolation_bc = IP.Line())
-KM_θ_dry = IP.LinearInterpolation(KM_data.z_centers[:], KM_data.θ_dry[:], extrapolation_bc = IP.Line())
-
-SD_T = IP.LinearInterpolation(sdm_data.z_sdm, sdm_data.T_sdm, extrapolation_bc = IP.Line())
-SD_p = IP.LinearInterpolation(sdm_data.z_sdm, sdm_data.P_sdm, extrapolation_bc = IP.Line())
-SD_ρ = IP.LinearInterpolation(sdm_data.z_sdm, sdm_data.rho_sdm, extrapolation_bc = IP.Line())
-SD_q_liq = IP.LinearInterpolation(sdm_data.z_sdm, sdm_data.ql_sdm, extrapolation_bc = IP.Line())
-SD_q_vap = IP.LinearInterpolation(sdm_data.z_sdm, sdm_data.qv_sdm, extrapolation_bc = IP.Line())
-SD_θ_dry = IP.LinearInterpolation(sdm_data.z_sdm, sdm_data.thetad_sdm, extrapolation_bc = IP.Line())
-
-# Test that the initial profiles match between CliMA and PySDM
-@testset "Initial profiles of water (vapour and liquid)" begin
-    z_test = z_min:100:z_max
-    @test all(isapprox(KM_q_vap(z_test), SD_q_vap(z_test), rtol = 1e-6))
-    @test all(isapprox(KM_q_liq(z_test), SD_q_liq(z_test), rtol = 1e-6))
-end
-@testset "Initial profiles of (T, p, ρ)" begin
-    z_test = z_min:100:z_max
-    @test all(isapprox(KM_T(z_test), SD_T(z_test), rtol = 1e-3))
-    @test all(isapprox(KM_p(z_test), SD_p(z_test), rtol = 1e-3))
-    @test all(isapprox(KM_ρ(z_test), SD_ρ(z_test), rtol = 1e-3))
-end
-@testset "Initial profiles of θ_dry" begin
-    z_test = z_min:100:z_max
-    @test all(isapprox(KM_θ_dry(z_test), SD_θ_dry(z_test), rtol = 1e-4))
-end
-
-# Plot the profiles - TODO connect with buildkite artifacts
-plot_comparison(KM_data, sdm_case = sdm_case, dir = sdm_case)
+compare_profiles(is_dry_flag = true)
+compare_profiles(is_dry_flag = false)


### PR DESCRIPTION
This PR adds the initial moist profile tests. 

They are currently broken - we still are figuring out the differences between PYSDM and CliMA setups.

