### PR TITLE
Add optional precipitation sinks, make precipitation sources optional

### DIFF
--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -17,6 +17,8 @@ const AKP = AbstractKinematicParameters
 Base.@kwdef struct KinematicParameters{FT, MP} <: AKP
     w1::FT
     t1::FT
+    precip_sources::Int
+    precip_sinks::Int
     microphys_params::MP
 end
 thermodynamics_params(ps::AKP) = CM.Parameters.thermodynamics_params(ps.microphys_params)
@@ -25,6 +27,8 @@ microphysics_params(ps::AKP) = ps.microphys_params
 Base.eltype(::KinematicParameters{FT}) where {FT} = FT
 w1(ps::AKP) = ps.w1
 t1(ps::AKP) = ps.t1
+precip_sources(ps::AKP) = ps.precip_sources
+precip_sinks(ps::AKP) = ps.precip_sinks
 
 # Forward parameters to Thermodynamics
 const TDPS = TD.Parameters.ThermodynamicsParameters

--- a/test/create_parameters.jl
+++ b/test/create_parameters.jl
@@ -11,6 +11,8 @@ function create_parameter_set(
     FTD = CP.float_type(toml_dict),
     w1 = 2.0,
     t1 = 600.0,
+    precip_sources = 1,
+    precip_sinks = 1,
 )
     FT = CP.float_type(toml_dict)
     override_file = joinpath(out_dir, "override_dict.toml")
@@ -55,6 +57,14 @@ function create_parameter_set(
         println(io, "alias = \"t1\"")
         println(io, "value = " * string(t1))
         println(io, "type = \"float\"")
+        println(io, "[precipitation_sources_flag]")
+        println(io, "alias = \"precip_sources\"")
+        println(io, "value = " * string(precip_sources))
+        println(io, "type = \"integer\"")
+        println(io, "[precipitation_sinks_flag]")
+        println(io, "alias = \"precip_sinks\"")
+        println(io, "value = " * string(precip_sinks))
+        println(io, "type = \"integer\"")
     end
     toml_dict = CP.create_toml_dict(FT; override_file, dict_type="alias")
     isfile(override_file) && rm(override_file; force=true)
@@ -73,7 +83,7 @@ function create_parameter_set(
     )
     MP = typeof(microphys_params)
 
-    aliases = ["w1", "t1"]
+    aliases = ["w1", "t1", "precip_sources", "precip_sinks"]
     pairs = CP.get_parameter_values!(toml_dict, aliases, "Kinematic1D")
 
     param_set = Kinematic1D.Parameters.KinematicParameters{FTD, MP}(; pairs..., microphys_params)

--- a/test/experiments/parse_commandline.jl
+++ b/test/experiments/parse_commandline.jl
@@ -18,6 +18,14 @@ function parse_commandline()
         help = "Set to true if you want to generate some basic plots at the end of the simulation"
         arg_type = Bool
         default = true
+        "--precip_sources"
+        help = "Set to true if you want to switch on autoconversion and accretion in the 1-moment scheme"
+        arg_type = Bool
+        default = true
+        "--precip_sinks"
+        help = "Set to true if you want to switch on evaporation, deposition, sublimation and melting in the 1-moment scheme"
+        arg_type = Bool
+        default = true
         "--z_min"
         help = "Bottom of the computational domain [m]"
         arg_type = Real

--- a/test/unit_tests/unit_test.jl
+++ b/test/unit_tests/unit_test.jl
@@ -253,7 +253,7 @@ end
 
     tmp = KiD.precip_helper_sources_1M!(params, ts, q_tot, q_liq, q_ice, q_rai, q_sno, T, ρ, dt)
     @test !isnan(tmp.S_q_tot .+ tmp.S_q_liq .+ tmp.S_q_ice .+ tmp.S_q_rai .+ tmp.S_q_sno)
-    @test tmp.S_q_tot ≈ tmp.S_q_liq + tmp.S_q_ice
+    @test tmp.S_q_tot ≈ tmp.S_q_liq + tmp.S_q_ice + tmp.S_q_vap
     @test tmp.S_q_tot ≈ -(tmp.S_q_rai + tmp.S_q_sno)
 
 end


### PR DESCRIPTION
This PR:

- adds precipitation sinks (evaporation, deposition, sublimation and melting) into 1-moment microphysics tendency. They can be switched on/off with the command line argument `--precip_sinks`,
- adds a command line argument to switch on/off the autoconversion and accretion in the 1-moment microphysics `--precip_sources`.

Both process groups are switched on by default. The parameter parsing function did not accept `Bool` as parameter type. Thats why I'm passing them as `Int`.

Also, the github marking of changes got very confused in the microphysics tendency part. In most of the file I just increased the indent because of the additional `if/else`.