### PR TITLE
making p0 an element of parameters

### DIFF
--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -17,6 +17,7 @@ const AKP = AbstractKinematicParameters
 Base.@kwdef struct KinematicParameters{FT, MP} <: AKP
     w1::FT
     t1::FT
+    p0::FT
     precip_sources::Int
     precip_sinks::Int
     microphys_params::MP
@@ -27,6 +28,7 @@ microphysics_params(ps::AKP) = ps.microphys_params
 Base.eltype(::KinematicParameters{FT}) where {FT} = FT
 w1(ps::AKP) = ps.w1
 t1(ps::AKP) = ps.t1
+p0(ps::AKP) = ps.p0
 precip_sources(ps::AKP) = ps.precip_sources
 precip_sinks(ps::AKP) = ps.precip_sinks
 

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -28,7 +28,6 @@ microphysics_params(ps::AKP) = ps.microphys_params
 Base.eltype(::KinematicParameters{FT}) where {FT} = FT
 w1(ps::AKP) = ps.w1
 t1(ps::AKP) = ps.t1
-p0(ps::AKP) = ps.p0
 precip_sources(ps::AKP) = ps.precip_sources
 precip_sinks(ps::AKP) = ps.precip_sinks
 

--- a/src/initial_condition.jl
+++ b/src/initial_condition.jl
@@ -32,7 +32,7 @@ function init_condition(::Type{FT}, params, z; dry = false) where {FT}
     θ_std::FT = z < z_1 ? θ_0 : θ_1 + (θ_2 - θ_1) / (z_2 - z_1) * (z - z_1)
 
     # density at the surface
-    p_0::FT = 1007.0 * 100.0
+    p_0 = params.p0
     SDM_θ_dry_0 = SDM_θ_dry(params, θ_0, qv_0)
     SDM_ρ_dry_0 = SDM_ρ_dry(params, p_0, qv_0, θ_0)
     SDM_T_0 = SDM_T(params, SDM_θ_dry_0, SDM_ρ_dry_0)

--- a/test/create_parameters.jl
+++ b/test/create_parameters.jl
@@ -11,6 +11,7 @@ function create_parameter_set(
     FTD = CP.float_type(toml_dict),
     w1 = 2.0,
     t1 = 600.0,
+    p0 = 100700.0,
     precip_sources = 1,
     precip_sinks = 1,
 )
@@ -57,6 +58,10 @@ function create_parameter_set(
         println(io, "alias = \"t1\"")
         println(io, "value = " * string(t1))
         println(io, "type = \"float\"")
+        println(io, "[surface_pressure]")
+        println(io, "alias = \"p0\"")
+        println(io, "value = " * string(p0))
+        println(io, "type = \"float\"")
         println(io, "[precipitation_sources_flag]")
         println(io, "alias = \"precip_sources\"")
         println(io, "value = " * string(precip_sources))
@@ -83,7 +88,7 @@ function create_parameter_set(
     )
     MP = typeof(microphys_params)
 
-    aliases = ["w1", "t1", "precip_sources", "precip_sinks"]
+    aliases = ["w1", "t1", "p0", "precip_sources", "precip_sinks"]
     pairs = CP.get_parameter_values!(toml_dict, aliases, "Kinematic1D")
 
     param_set = Kinematic1D.Parameters.KinematicParameters{FTD, MP}(; pairs..., microphys_params)

--- a/test/experiments/KiD_driver.jl
+++ b/test/experiments/KiD_driver.jl
@@ -75,6 +75,7 @@ params = create_parameter_set(
     FT,
     opts["w1"],
     opts["t1"],
+    opts["p0"],
     Int(opts["precip_sources"]),
     Int(opts["precip_sinks"]),
 )

--- a/test/experiments/parse_commandline.jl
+++ b/test/experiments/parse_commandline.jl
@@ -62,6 +62,10 @@ function parse_commandline()
         help = "Oscillation time of the prescribed momentum flux [s]"
         arg_type = Real
         default = 600.0
+        "--p0"
+        help = "Pressure at the surface [pa]"
+        arg_type = Real
+        default = 100700.0
     end
 
     return AP.parse_args(s)


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content
This pull request makes p0 an element of the object parameters. The goal is to be able to change p0 in simulations.

## Benefits and Risks
p0 can be changed via command line. The default value is the same as before. So I don't think this PR breaks any tests or produce any inconsistent results. Hopefully there is no risk.

## Linked Issues
none

## PR Checklist
- This PR has a corresponding issue OR is linked to an SDI.
- I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- I linted my code on my local machine prior to submission OR N/A.
- Unit tests are included OR N/A.
- Code used in an integration test OR N/A.
- All tests ran successfully on my local machine OR N/A.
- All classes, modules, and function contain docstrings OR N/A.
- Documentation has been added/updated OR N/A.
