### PR TITLE
Add timeheight plots to the default plots profile

### DIFF
--- a/test/experiments/KiD_driver.jl
+++ b/test/experiments/KiD_driver.jl
@@ -153,5 +153,5 @@ if opts["plotting_flag"] == true
     z_centers = parent(CC.Fields.coordinate_field(space))
     plot_final_aux_profiles(z_centers, aux, output = plot_folder)
     plot_animation(z_centers, solver, aux, moisture, precip, KID, output = plot_folder)
-    plot_timeheight(string("experiments/", output_folder, "/Output.nc"))
+    plot_timeheight(string("experiments/", output_folder, "/Output.nc"), output = plot_folder)
 end

--- a/test/experiments/parse_commandline.jl
+++ b/test/experiments/parse_commandline.jl
@@ -62,7 +62,7 @@ function parse_commandline()
         "--dt_output"
         help = "Output time step [s]"
         arg_type = Real
-        default = 10.0
+        default = 30.0
         "--t_ini"
         help = "Time at the beginning of the simulation [s]"
         arg_type = Real


### PR DESCRIPTION
I just noticed that the time-height plots were saved somewhere else than the rest. So I moved them.

Also, they take a little long to plot. Might be worth to switch them off by default (maybe)? I reduced the default output frequency, but it's still kind of slow there.