### PR TITLE
Fixes to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The `KiD_driver.jl` inside `test/experiments/KiD_driver` folder is
 It accepts some command line arguments,
   see the `--help` for details.
 ```bash
-julia --project=test/ test/experiments/KiD_driver.jl --help
+julia --project=test/ test/experiments/KiD_driver/KiD_driver.jl --help
 ```
 
 An example command to run the `Kid_driver.jl` from terminal:
@@ -58,7 +58,7 @@ An example command to run the `Kid_driver.jl` from terminal:
 julia --color=yes --project=test test/experiments/KiD_driver/KiD_driver.jl --moisture_choice=NonEquilibriumMoisture --precipitation_choice=Precipitation1M
 ```
 
-In addition to simulating the 1D rainshaft, Kinematic1D.jl provides tools for calibrating microphysics parameters against availabkle data. The main program for running calibrations is given inside `test/experiments/calibrations` folder. This program is accompanied by the `config.jl` file that defines all the settings for the dynamics, observations, optimization process, and parameters to be calibrated. To run calibrations of microphysics schemes by using Kinematic1D the `config.jl` file needs to be adjusted. Then the program can be called from terminal:
+In addition to simulating the 1D rainshaft, Kinematic1D.jl provides tools for calibrating microphysics parameters against available data. The main program for running calibrations is given inside `test/experiments/calibrations` folder. This program is accompanied by the `config.jl` file that defines all the settings for the dynamics, observations, optimization process, and parameters to be calibrated. To run calibrations of microphysics schemes by using Kinematic1D the `config.jl` file needs to be adjusted. Then the program can be called from terminal:
 ```bash
 julia --color=yes --project=test test/experiments/calibrations/run_calibrations.jl
 ```


### PR DESCRIPTION
Saving the images as .png didn't work, so I changed the plotting_utils.jl to save files as .pdf instead. I made minor changes to the README.md (updating a path). 

The error I got was that the file "libtiff.5.dylib" does not exist. 

Here's the error:
GKS: dlopen(/Users/Apoorva/.julia/artifacts/965cbb25c209939b5dddf8d0d9210febdd72016e/lib/cairoplugin.so, 0x0001): Library not loaded: @rpath/libtiff.5.dylib
  Referenced from: /Users/Apoorva/.julia/artifacts/965cbb25c209939b5dddf8d0d9210febdd72016e/lib/cairoplugin.so
  Reason: tried: '/Users/Apoorva/.julia/artifacts/965cbb25c209939b5dddf8d0d9210febdd72016e/lib/./libtiff.5.dylib' (no such file), '/Users/Apoorva/.julia/artifacts/965cbb25c209939b5dddf8d0d9210febdd72016e/lib/./libtiff.5.dylib' (no such file), '/workspace/destdir/lib/libtiff.5.dylib' (no such file), '/Users/Apoorva/.julia/artifacts/965cbb25c209939b5dddf8d0d9210febdd72016e/lib/./libtiff.5.dylib' (no such file), '/Applications/Julia-1.9.app/Contents/Resources/julia/bin/../lib/libtiff.5.dylib' (no such file), '/usr/local/lib/libtiff.5.dylib' (no such file), '/usr/lib/libtiff.5.dylib' (no such file)
"/Users/Apoorva/CLIMA/Kinematic1D.jl/test/experiments/KiD_driver/Output_NonEquilibriumMoisture_RhoThetaQ_Precipitation1M_CliMA_1M/figures/timeheight.png"