### PR TITLE
Changed the arg_type of command-line arguments for KiD_driver from Re…

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -76,8 +76,8 @@ steps:
         command: "julia --color=yes --project=test test/experiments/KiD_driver/KiD_driver.jl --moisture_choice=NonEquilibriumMoisture --prognostic_vars=RhodTQ --precipitation_choice=Precipitation1M"
         artifact_paths: "test/experiments/KiD_driver/Output_NonEquilibriumMoisture_RhodTQ_Precipitation1M_CliMA_1M/figures/*"
 
-      - label: ":crystal_ball: Experiments: equil (fixed rhod and T) + KK2000 "
-        command: "julia --color=yes --project=test test/experiments/KiD_driver/KiD_driver.jl --moisture_choice=EquilibriumMoisture --prognostic_vars=RhodTQ --precipitation_choice=Precipitation1M --rain_formation_scheme_choice KK2000 --prescribed_Nd 1e8"
+      - label: ":crystal_ball: Experiments: equil (fixed rhod and T) + KK2000 + Float32 "
+        command: "julia --color=yes --project=test test/experiments/KiD_driver/KiD_driver.jl --FLOAT_TYPE=Float32 --moisture_choice=EquilibriumMoisture --prognostic_vars=RhodTQ --precipitation_choice=Precipitation1M --rain_formation_scheme_choice KK2000 --prescribed_Nd 1e8"
         artifact_paths: "test/experiments/KiD_driver/Output_EquilibriumMoisture_RhodTQ_Precipitation1M_KK2000/figures/*"
 
       - label: ":crystal_ball: Experiments: equil (fixed rhod and T) + B1994 "

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.8.1'
+          - '1.8.5'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/test/experiments/KiD_driver/KiD_driver.jl
+++ b/test/experiments/KiD_driver/KiD_driver.jl
@@ -28,11 +28,11 @@ const KID = Kinematic1D
 const AP = ArgParse
 const CMT = CloudMicrophysics.CommonTypes
 
-const FT = Float64
-
 # Get the parameter values for the simulation
 include("parse_commandline.jl")
 opts = parse_commandline()
+
+const FT = opts["FLOAT_TYPE"] == "Float64" ? Float64 : Float32
 
 # Equations to solve for mositure and precipitation variables
 moisture_choice = opts["moisture_choice"]
@@ -83,7 +83,7 @@ end
 TS = KID.TimeStepping(FT(opts["dt"]), FT(opts["dt_output"]), FT(opts["t_end"]))
 
 # Create the coordinates
-space, face_space = KID.make_function_space(FT, opts["z_min"], opts["z_max"], opts["n_elem"])
+space, face_space = KID.make_function_space(FT, FT(opts["z_min"]), FT(opts["z_max"]), opts["n_elem"])
 coord = CC.Fields.coordinate_field(space)
 face_coord = CC.Fields.coordinate_field(face_space)
 
@@ -106,9 +106,9 @@ params = create_parameter_set(
     path,
     toml_dict,
     FT,
-    opts["w1"],
-    opts["t1"],
-    opts["p0"],
+    FT(opts["w1"]),
+    FT(opts["t1"]),
+    FT(opts["p0"]),
     Int(opts["precip_sources"]),
     Int(opts["precip_sinks"]),
     Int(opts["qtot_flux_correction"]),
@@ -141,7 +141,7 @@ callbacks = ODE.CallbackSet(callback_io)
 ode_rhs! = KID.make_rhs_function(moisture, precip)
 
 # Solve the ODE operator
-problem = ODE.ODEProblem(ode_rhs!, Y, (opts["t_ini"], opts["t_end"]), aux)
+problem = ODE.ODEProblem(ode_rhs!, Y, (FT(opts["t_ini"]), FT(opts["t_end"])), aux)
 solver = ODE.solve(
     problem,
     ODE.SSPRK33(),

--- a/test/experiments/KiD_driver/parse_commandline.jl
+++ b/test/experiments/KiD_driver/parse_commandline.jl
@@ -6,6 +6,10 @@ function parse_commandline()
     s = AP.ArgParseSettings()
 
     AP.@add_arg_table! s begin
+        "--FLOAT_TYPE"
+        help = "Float type. Can be set to Float64 or Float32"
+        arg_type = String
+        default = "Float64"
         "--moisture_choice"
         help = "Mositure model choice: EquilibriumMoisture, NonEquilibriumMoisture"
         arg_type = String
@@ -45,56 +49,56 @@ function parse_commandline()
         default = false
         "--z_min"
         help = "Bottom of the computational domain [m]"
-        arg_type = Real
-        default = 0.0
+        arg_type = Float64
+        default = Float64(0)
         "--z_max"
         help = "Top of the computational domain [m]"
-        arg_type = Real
-        default = 2000.0
+        arg_type = Float64
+        default = Float64(2000)
         "--n_elem"
         help = "Number of computational elements"
         arg_type = Int
         default = 256
         "--dt"
         help = "Simulation time step [s]"
-        arg_type = Real
-        default = 1.0
+        arg_type = Float64
+        default = Float64(1)
         "--dt_output"
         help = "Output time step [s]"
-        arg_type = Real
-        default = 30.0
+        arg_type = Float64
+        default = Float64(30)
         "--t_ini"
         help = "Time at the beginning of the simulation [s]"
-        arg_type = Real
-        default = 0.0
+        arg_type = Float64
+        default = Float64(0)
         "--t_end"
         help = "Time at the end of the simulation [s]"
-        arg_type = Real
-        default = 3600.0
+        arg_type = Float64
+        default = Float64(3600)
         "--w1"
         help = "Maximum prescribed updraft momentum flux [m/s * kg/m3]"
-        arg_type = Real
-        default = 2.0
+        arg_type = Float64
+        default = Float64(2)
         "--t1"
         help = "Oscillation time of the prescribed momentum flux [s]"
-        arg_type = Real
-        default = 600.0
+        arg_type = Float64
+        default = Float64(600)
         "--p0"
         help = "Pressure at the surface [pa]"
-        arg_type = Real
-        default = 100000.0
+        arg_type = Float64
+        default = Float64(100000)
         "--r_dry"
         help = "aerosol distribution mean radius for aerosol activation calculations in 2M schemes [m]"
-        arg_type = Real
-        default = 0.04 * 1e-6
+        arg_type = Float64
+        default = Float64(0.04 * 1e-6)
         "--std_dry"
         help = "aerosol distribution standard deviation for aerosol activation calucaulations in 2M schemes"
-        arg_type = Real
-        default = 1.4
+        arg_type = Float64
+        default = Float64(1.4)
         "--kappa"
         help = "hygroscopicity of aerosols for aerosol activation calucaulations in 2M schemes"
-        arg_type = Real
-        default = 0.9
+        arg_type = Float64
+        default = Float64(0.9)
     end
 
     return AP.parse_args(s)


### PR DESCRIPTION
…al to Float64

Also, enable `Float32` runs

<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
The parsing of the command-line arguments (e.g. `--t_end`) was not working properly when their `arg_type` was set to `Real`:
`invalid argument: 1000.0 (conversion to type Real failed; you may need to overload
                  ArgParse.parse_item; the error was: MethodError(tryparse, (Real, "1000.0"), 0x0000000000008433))`
Changing the `arg_type` to `Float64` fixed the issue.


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
